### PR TITLE
Fix display of menu item type "Heading"

### DIFF
--- a/components/com_xmap/displayer.php
+++ b/components/com_xmap/displayer.php
@@ -163,6 +163,7 @@ class XmapDisplayer {
             switch ($item->type)
             {
                 case 'separator':
+                case 'heading':
                     $node->browserNav=3;
                     break;
                 case 'url':


### PR DESCRIPTION
Joomla!3 added a new system menu item type called "Heading" very similar in display to "Text Separator". This fixes adding broken links to the sitemap.
