### PR TITLE
Fix default site map

### DIFF
--- a/components/com_xmap/models/sitemap.php
+++ b/components/com_xmap/models/sitemap.php
@@ -43,6 +43,16 @@ class XmapModelSitemap extends JModelItem
 
         // Load state from the request.
         $pk = JRequest::getInt('id');
+
+        // If not sitemap specified, select the default one
+        if (!$pk) {
+            $db = $this->getDbo();
+            $query = $db->getQuery(true);
+            $query->select('id')->from('#__xmap_sitemap')->where('is_default=1');
+            $db->setQuery($query);
+            $pk = $db->loadResult();
+        }
+
         $this->setState('sitemap.id', $pk);
 
         $offset = JRequest::getInt('limitstart');
@@ -69,14 +79,6 @@ class XmapModelSitemap extends JModelItem
         // Initialize variables.
         $db = $this->getDbo();
         $pk = (!empty($pk)) ? $pk : (int) $this->getState('sitemap.id');
-
-        // If not sitemap specified, select the default one
-        if (!$pk) {
-            $query = $db->getQuery(true);
-            $query->select('id')->from('#__xmap_sitemap')->where('is_default=1');
-            $db->setQuery($query);
-            $pk = $db->loadResult();
-        }
 
         if ($this->_item === null) {
             $this->_item = array();


### PR DESCRIPTION
http://example.com/index.php?option=com_xmap&view=xml
or (SEF)
http://example.com/component/xmap/xml

The default site map was not showing manual edits made to the
"Change Freq." and "Priority" for individual items.  The
correct row from the #__xmap_items table was not being
retrieved.
